### PR TITLE
Fix typo on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ end
 Nest a test group with description. `.context` is an alias.
 
 ```ruby
-describe do "GET /me"
+describe "GET /me" do
   context "without logged-in" do
     it "returns 401" do
       assert { response.status == 200 }


### PR DESCRIPTION
I found a typo on README compared with following line, so I fixed it 😃 
https://github.com/petitest/petitest-spec/commit/e1854522148a20c973014e55e1e0af73d41b7311#diff-b61483b7e7e014f9d639db5513ba351bR13